### PR TITLE
change bubbly url to appteamcarolina.com/bubbly

### DIFF
--- a/bubbly/index.html
+++ b/bubbly/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="icon" type="image/png" href="/assets/bubbly-assets/bubbly-favicon.svg">
+    <title>Bubbly</title>
+    <link rel="stylesheet" href="/css/bubbly.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+
+<body>
+    <!--- LANDING PAGE --->
+    <div class="flex-container">
+        <!--- Left pane --->
+        <div class="left">
+            <!--- Align contents of left pane vertically center --->
+            <div class="aligner">
+                <div>
+                    <img class="logo" src="/assets/bubbly-assets/logo-3x.png" alt="Bubbly Logo">
+                    <p class="caption">
+                        The perfect reading and spelling experience to navigate CVI.
+                    </p>
+                    <div class="button-section">
+                        <div class="button-container">
+                            <a href="https://apps.apple.com/us/app/bubbly-cvi-literacy/id1616368300" target="_blank"
+                                class="button" id="download_button"><img
+                                    src="/assets/bubbly-assets/appstoredownload.svg" alt="Download Button"></a>
+                            <a href="#demo" class="button" id="video_button"><img
+                                    src="/assets/bubbly-assets/playvideo.png" alt="Video Demo Button"></a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <!--- Right pane --->
+        <div class="right">
+            <div class="aligner">
+                <!--- Align contents of left pane vertically center --->
+                <div>
+                    <img class="mockupimage" src="/assets/bubbly-assets/mockup.png" alt="Bubbly Mockup">
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="demo">
+        <h1 class="title">Video Demo</h1>
+        <video controls>
+            <source src="/assets/bubbly-assets/bubbly-demo.mov" type="video/mp4">
+            Your browser does not support the video tag.
+        </video>
+    </div>
+
+    <!--- FOOTER --->
+    <div id="footer">
+        <div class="footer-content">
+            <p id="copyright">Made with &hearts; by App Team Carolina in Chapel Hill, NC &copy; 2022</p>
+            <div id="navig">
+                <a href="privacy.html">Privacy Policy</a>
+                <a href="terms.html">Terms and Conditions</a>
+            </div>
+        </div>
+    </div>
+
+</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -389,7 +389,7 @@
                                 and adolescents with Cortical Visual Impairment (CVI), a disorder that is caused by damage to the parts 
                                 of the brain that process vision, which disrupts the brain's communication with the eyes.
                             </p>
-                            <a href="bubbly/bubbly.html"><div class="button secondary">Tell me more!</div></a>
+                            <a href="bubbly"><div class="button secondary">Tell me more!</div></a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Added an `index.html` file to the `bubbly/` directory that allows the bubbly URL to simply be `appteamcarolina.com/bubbly` instead of `appteamcarolina.com/bubbly/bubbly.html`. I left `bubbly.html` in there because we've given the old URL to App Store Connect. But, with the next version of the app that we submit to the app store, we should change the URL and delete the old file